### PR TITLE
refactor: remove identity hack from Lazy types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fattafatta/rescript-solidjs",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fattafatta/rescript-solidjs",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "rescript": "^9.1.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fattafatta/rescript-solidjs",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "ReScript bindings for solid-js.",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
Removed usage of "%identity" external from "Lazy.make". "%identity" should only be used as a last
resort.